### PR TITLE
Fixed imported css no attributes

### DIFF
--- a/django/pyproject.toml
+++ b/django/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "django_vite_plugin"
-version = "1.0.0"
+version = "1.0.1"
 authors = [
   { name="Sakibur Rahman Khan", email="sakib.saad.khan@gmail.com" },
 ]

--- a/django/src/django_vite_plugin/utils.py
+++ b/django/src/django_vite_plugin/utils.py
@@ -67,7 +67,6 @@ def _get_css_files(
             if css_path not in already_processed:
                 html += get_html(
                     urljoin(CONFIG['BUILD_URL_PREFIX'], css_path),
-                    '',
                     attrs
                 )
             already_processed.append(css_path)

--- a/django/src/django_vite_plugin/utils.py
+++ b/django/src/django_vite_plugin/utils.py
@@ -15,6 +15,12 @@ if CONFIG['BUILD_URL_PREFIX'][-1] != "/":
     CONFIG['BUILD_URL_PREFIX'] += "/"
 
 VITE_MANIFEST  = {}
+
+# Compile the default css attributes beforehand
+DEFAULT_CSS_ATTRS = " ".join(
+    [f'{key}="{value}"' for key, value in CONFIG['CSS_ATTRS'].items()]
+)
+
 if not CONFIG['DEV_MODE']:
     manifest_path = getattr(settings, 'BASE_DIR') / CONFIG['BUILD_DIR'].lstrip('/\\') / 'manifest.json'
     try:
@@ -36,7 +42,10 @@ def get_from_manifest(path: str, attrs: Dict[str, str]) -> str:
         )
     
     manifest_entry = VITE_MANIFEST[path]
-    assets = _get_css_files(manifest_entry, attrs)
+    assets = _get_css_files(manifest_entry, {
+        # The css files of a js 'import' should get the default attributes
+        'css': DEFAULT_CSS_ATTRS
+    })
     assets += get_html(
         urljoin(CONFIG['BUILD_URL_PREFIX'], manifest_entry["file"]),
         attrs

--- a/example/home/static/home/css/imported.css
+++ b/example/home/static/home/css/imported.css
@@ -1,0 +1,3 @@
+.just-nothing {
+    display: none;
+}

--- a/example/home/static/home/js/app.js
+++ b/example/home/static/home/js/app.js
@@ -2,6 +2,7 @@ import { find } from './utils'
 import { createApp } from 'vue'
 import { showAlert } from '@s:home/js/deep/deep.js'
 import VueCounter from '@t:home/vue/counter.vue'
+import '@s:home/css/imported.css'
 
 find("#next-move").addEventListener("click", showAlert);
 

--- a/example/home/templates/index.html
+++ b/example/home/templates/index.html
@@ -49,12 +49,12 @@
         <div class="grid grid-cols-2 p-4 text-gray-500">
             <div>
                 {% verbatim %}
-                    {% vite 'another_app/js/one.js' %}
+                    {% vite 'home/js/app.js' %}
                 {% endverbatim %}
             </div>
             <div>
                 {% html %}
-                    {% vite 'another_app/js/one.js' %}
+                    {% vite 'home/js/app.js' %}
                 {% endhtml %}
             </div>
         </div>


### PR DESCRIPTION
The imported css from js files used to have no attributes
```javascript
import 'some.css'
```
Old Output:
```html
<link href="some.css" />
```
Fixed: 
```html
<link rel="stylesheet" type="text/css" href="some.css" />
```