### PR TITLE
Add `pyPath` option to allow setting different python executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,8 @@ The available js configuration options are:
 {
     input: string | string[],
     root?: string,
-    addAliases?: boolean, 
+    addAliases?: boolean,
+    pyPath?: string, 
 }
 ```
 
@@ -218,6 +219,8 @@ The available js configuration options are:
 - `root` : The relative path from your `vite.config.js` to your project's root directory. If they are the same (which is recommended) skip it.
 
 - `addAliases` : Whether to add the `@s:<app>` & `@t:<app>` aliases in the `jsconfig.json` file. If set `true` then will create a `jsconfig.json` if not exists. Default is it will add aliases if `jsconfig.json` file exists
+
+- `pyPath` : The path to your python executable. (Default: `python`)
 
 Let's assume your `vite.config.js` file is in `frontend` directory
 ```bash

--- a/vite/package.json
+++ b/vite/package.json
@@ -1,6 +1,6 @@
 {
     "name": "django-vite-plugin",
-    "version": "1.1.2",
+    "version": "1.1.3",
     "description": "Django plugin for Vite.",
     "keywords": [
         "django",


### PR DESCRIPTION
The plugin used to run
```bash
python manage.py 'arg1' 'arg2'
```
Now, there is an option to customize the python executable path.
```javascript
export default defineConfig({
    plugins: [
        ...
        djangoVite({
            ...
            pyPath: './to/idk/python'
        })
    ],
});
```
This would result in running the following command:
```bash
./to/idk/python manage.py 'arg1' 'arg2'
```