### PR TITLE
add type for djangoVitePlugin "list mode"

### DIFF
--- a/vite/src/index.ts
+++ b/vite/src/index.ts
@@ -69,7 +69,7 @@ type DevServerUrl = `${'http'|'https'}://${string}:${number}`
 let DJANGO_VERSION = '...'
 
 
-export default async function djangoVitePlugin (config: PluginConfig) : Promise<Plugin[]>{
+export default async function djangoVitePlugin (config: PluginConfig | string[]) : Promise<Plugin[]>{
     process.stdout.write("Loading configurations...\r")
     const appConfig = JSON.parse(await execPython(['--action', 'config'], config))
 


### PR DESCRIPTION
fixes
```
Argument of type 'string[]' is not assignable to parameter of type 'PluginConfig'.
```
when doing 

```
import { defineConfig } from 'vite'
import djangoVite from 'django-vite-plugin'

export default defineConfig({
    plugins: [
        djangoVite([
            'app/tailwind.css',
        ])
    ],
})
```