### PR TITLE
BUILD_DIR needs to be converted to str for all Path-kind

### DIFF
--- a/django/src/django_vite_plugin/management/commands/django_vite_plugin.py
+++ b/django/src/django_vite_plugin/management/commands/django_vite_plugin.py
@@ -11,7 +11,7 @@ import pathlib
 CONFIG = get_config()
 if isinstance(CONFIG["BUILD_DIR"], str):
     CONFIG["BUILD_DIR"] = CONFIG["BUILD_DIR"].strip("/\\")
-elif isinstance(CONFIG["BUILD_DIR"], pathlib.WindowsPath):
+elif isinstance(CONFIG["BUILD_DIR"], pathlib.Path):
     CONFIG["BUILD_DIR"] = str(CONFIG["BUILD_DIR"])
 
 


### PR DESCRIPTION
Otherwise `json.dumps(CONFIG)` may fail later.