### PR TITLE
Prioritize options passed via npm script or vite config

### DIFF
--- a/vite/src/config.ts
+++ b/vite/src/config.ts
@@ -135,12 +135,12 @@ export function resolveServerConfig(
               }
             : undefined
     return {
-        ...(front || {}),
         origin: `http${https ? 's' : ''}://${host}:${port}`,
         host,
         port,
         strictPort: true,
         https,
+        ...(front || {}),
     }
 }
 


### PR DESCRIPTION
## Prioritize options passed via npm script or vite config
Right now, if we pass config options via npm in the command line or via `vite.config.js` they will be overridden with configs passed in Django settings.

**Command line**
```shell
npm run dev -- --host 0.0.0.0
```

**vite.config.js**
```js
import { defineConfig } from "vite";
import { djangoVitePlugin } from "django-vite-plugin";

export default defineConfig({
  server:{
    host:true
  },
  plugins: [
    djangoVitePlugin({
      input: [
        "src/styles/style.scss", 
        "src/js/app.js", 
      ],
      root: "..",
    }),
  ],
});
```
The above config has no effect on the Vite server.

## Expected Vite Docker Container Behavior
The default behavior for using Vite in a docker container is to pass `--host` to npm script or add `host` in the server option of the config.


This pull request address that and prioritize options passed from Vite.
