### PR TITLE
fix recursive imports from manifest

### DIFF
--- a/django/src/django_vite_plugin/utils.py
+++ b/django/src/django_vite_plugin/utils.py
@@ -96,7 +96,7 @@ def _get_css_files(
     if 'imports' in manifest_entry:
         for import_path in manifest_entry['imports']:
             html += _get_css_files(
-                import_path,
+                VITE_MANIFEST[import_path],
                 attrs,
                 already_processed
             )


### PR DESCRIPTION
Hi,
I have an issue with recursive imports from the vite manifest. Let me explain. With the production build, vite is splitting into different chunks my `js` code, like this for instance :
```
static/.vite/manifest.json                              6.05 kB │ gzip:   0.96 kB
static/assets/contact_info-BONdzhdf.css                 0.04 kB │ gzip:   0.06 kB
static/assets/annuaire-BD7dvoKS.css                     0.16 kB │ gzip:   0.15 kB
static/assets/menu_bar-B1DNQiR2.css                   243.05 kB │ gzip:  34.83 kB
static/assets/vue-router-oFY6fX0y.js                   88.67 kB │ gzip:  31.06 kB
static/assets/annuaire-Bw0mGyaT.js                    275.47 kB │ gzip:  80.65 kB
static/assets/menu_bar-Cg_ihQeU.js                  1,308.06 kB │ gzip: 341.85 kB
```
My entry point is only one js file `annuaire.js` and the vite `manifest.json` looks like this : 
```
{
  "_contact_info-!~{00h}~.js": {
    "file": "assets/contact_info-BONdzhdf.css",
    "src": "_contact_info-!~{00h}~.js"
  },
  "_contact_info-qI9Vj_GE.js": {
    "file": "assets/contact_info-qI9Vj_GE.js",
    "name": "contact_info",
    "imports": [
      "_menu_bar-Cg_ihQeU.js",
      "_vue-router-oFY6fX0y.js"
    ],
    "css": [
      "assets/contact_info-BONdzhdf.css"
    ]
  },
  "_menu_bar-!~{00b}~.js": {
    "file": "assets/menu_bar-B1DNQiR2.css",
    "src": "_menu_bar-!~{00b}~.js"
  },
  "_menu_bar-Cg_ihQeU.js": {
    "file": "assets/menu_bar-Cg_ihQeU.js",
    "name": "menu_bar",
    "css": [
      "assets/menu_bar-B1DNQiR2.css"
    ]
  },
  "_search-Cdf3p1k0.js": {
    "file": "assets/search-Cdf3p1k0.js",
    "name": "search",
    "imports": [
      "_menu_bar-Cg_ihQeU.js"
    ]
  },
  "_vue-router-oFY6fX0y.js": {
    "file": "assets/vue-router-oFY6fX0y.js",
    "name": "vue-router",
    "imports": [
      "_menu_bar-Cg_ihQeU.js"
    ]
  },
  "annuaire/static/annuaire/js/annuaire.js": {
    "file": "assets/annuaire-Bw0mGyaT.js",
    "name": "annuaire",
    "src": "annuaire/static/annuaire/js/annuaire.js",
    "isEntry": true,
    "imports": [
      "_menu_bar-Cg_ihQeU.js",
      "_vue-router-oFY6fX0y.js",
      "_contact_info-qI9Vj_GE.js"
    ],
    "css": [
      "assets/annuaire-BD7dvoKS.css"
    ]
  },
}
```
`django-vite-plugin` has no problem to add the related css file (`annuaire-BD7dvoKS.css` in this case). But when it comes to recursively find other css imports `menu_bar-B1DNQiR2.css` for instance from `_menu_bar-Cg_ihQeU.js`, it fails since the function `_get_css_files` in `utils.py` should have a `manifest_entry` `Dict` and not a path. This PR fix this.