### PR TITLE
Replace apps loading

### DIFF
--- a/django/src/django_vite_plugin/management/commands/django_vite_plugin.py
+++ b/django/src/django_vite_plugin/management/commands/django_vite_plugin.py
@@ -40,15 +40,13 @@ class Command(BaseCommand):
             )
     
     def get_apps(self) -> Dict[str, str]:
-        INSTALLED_APPS = getattr(settings, 'INSTALLED_APPS', [])
-        APPS = {}
-        for app in INSTALLED_APPS:
-            # Ignore dotted named apps
-            if '.' in app or app == 'django_vite_plugin':
+        APPS= {}
+        app_configs = apps.get_app_configs()
+        for app_config in app_configs:
+            name = app_config.name
+            if '.' in name or name == 'django_vite_plugin':
                 continue
-            APPS[app] = apps.get_app_config(app).path
-
-        return APPS
+            APPS[name] = app_config.path
     
 
     def print_config(self):

--- a/django/src/django_vite_plugin/management/commands/django_vite_plugin.py
+++ b/django/src/django_vite_plugin/management/commands/django_vite_plugin.py
@@ -47,7 +47,7 @@ class Command(BaseCommand):
             if '.' in name or name == 'django_vite_plugin':
                 continue
             APPS[name] = app_config.path
-    
+        return APPS
 
     def print_config(self):
         CONFIG = get_config()


### PR DESCRIPTION
As suggesting by @hfroot, the actual function that loads applications can raise an error in case a package have a different **name** and **label**, like the package wagtail. 

This proposition uses django's offical `get_app_configs()`
 