### PR TITLE
Allow to have a separate ESM compatible build

### DIFF
--- a/vite/package.json
+++ b/vite/package.json
@@ -2,6 +2,7 @@
     "name": "django-vite-plugin",
     "version": "4.0.1",
     "description": "Django plugin for Vite.",
+    "type": "module",
     "keywords": [
         "django",
         "vite",
@@ -17,14 +18,23 @@
         "name": "Sakibur Rahman Khan",
         "email": "sakib.saad.khan@gmail.com"
     },
-    "main": "dist/index.js",
-    "types": "dist/index.d.ts",
+    "module": "./dist/esm/index.js",
+    "types": "./dist/esm/index.d.ts",
+    "main": "./dist/cjs/index.js",
+    "exports": {
+      "./package.json": "./package.json",
+      ".": {
+        "import": "./dist/esm/index.js",
+        "types": "./dist/esm/index.d.ts",
+        "require": "./dist/cjs/index.js"
+      }
+    },
     "files": [
-        "/dist"
+      "dist/**/*"
     ],
     "scripts": {
-        "build": "rm -rf dist && tsc && cp src/info.html dist/",
-        "build-win": "rmdir /s /q dist && tsc && copy \".\\src\\info.html\" \".\\dist\\\"",
+        "build": "rm -rf dist && tsc && tsc -t es2019 -m commonjs -d false --outDir dist/cjs && cp src/info.html dist/esm/ && cp src/info.html dist/cjs/ && cp src/package-esm.json dist/esm/package.json && cp src/package-cjs.json dist/cjs/package.json",
+        "build-win": "rmdir /s /q dist && tsc && tsc -t es2019 -m commonjs -d false --declarationDir null --outDir dist\\cjs && copy \".\\src\\info.html\" \".\\dist\\esm\\\" && copy \".\\src\\info.html\" \".\\dist\\cjs\\\" && copy \".\\src\\package-esm.json\" \".\\dist\\esm\\package.json\" && copy \".\\src\\package-cjs.json\" \".\\dist\\cjs\\package.json\"",
         "lint": "eslint --ext .ts ./src"
     },
     "devDependencies": {
@@ -32,6 +42,7 @@
         "@typescript-eslint/eslint-plugin": "^5.62.0",
         "@typescript-eslint/parser": "^5.62.0",
         "prettier": "^3.2.5",
+        "tsc": "^2.0.4",
         "typescript": "^4.9.5",
         "vite": "^4.5.3"
     },

--- a/vite/src/package-cjs.json
+++ b/vite/src/package-cjs.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/vite/src/package-esm.json
+++ b/vite/src/package-esm.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/vite/tsconfig.json
+++ b/vite/tsconfig.json
@@ -1,8 +1,8 @@
 {
     "compilerOptions": {
-        "outDir": "./dist",
-        "target": "ES2019",
-        "module":"CommonJS",
+        "outDir": "./dist/esm",
+        "target": "es2022",
+        "module":"es2022",
         "moduleResolution": "node",
         "resolveJsonModule": true,
         "strict": true,


### PR DESCRIPTION
Based on a blog post of Charles Loder:
https://dev.to/charlesloder/publishing-esm-and-commonjs-packages-with-typescript-4e20

This will offer two different folders for a ESM project (`type: module`) or a legacy CommonJs project..

---

Tested with the following **CommonJS** `package.json`:
```json
{
  "name": "test-cjs",
  "version": "1.0.0",
  "main": "index.js",
  "dependencies": {
    "django-vite-plugin": "./django-vite-plugin-v4.0.1.tgz"
  }
}
```
and `index.js`:
```js
const django_vite_plugin = require('django-vite-plugin');
const djangoVitePlugin = django_vite_plugin.djangoVitePlugin;

console.log(djangoVitePlugin)
```

This produces the correct output with node:
```
$ node index.js
The CJS build of Vite's Node API is deprecated. See https://vitejs.dev/guide/troubleshooting.html#vite-cjs-node-api-deprecated for more details.
[AsyncFunction: djangoVitePlugin]
```

---

And here with the following **ESM** `package.json`:
```json
{
  "name": "test-esm",
  "version": "1.0.0",
  "main": "index.js",
  "type": "module",
  "dependencies": {
    "django-vite-plugin": "./django-vite-plugin-v4.0.1.tgz"
  }
}
```
and `index.js`:
```js
import { djangoVitePlugin } from 'django-vite-plugin';

console.log(djangoVitePlugin)
```

This produces the correct output with node:
```
$ node index.js
[AsyncFunction: djangoVitePlugin]
```