### PR TITLE
Fix typo in `README.md`

### DIFF
--- a/django/README.md
+++ b/django/README.md
@@ -23,7 +23,7 @@ INSTALLED_APPS = [
 ]
 ```
 These are the available configuration options
-```pyhton
+```python
 # Other settings
 DJANGO_VITE_PLUGIN = {
     'WS_CLIENT': '@vite/client',


### PR DESCRIPTION
This fixes syntax highlighting.