### PR TITLE
fix unsupported operand '/' on str. Make sure BASE_DIR is a path befo…

### DIFF
--- a/django/src/django_vite_plugin/config_helper.py
+++ b/django/src/django_vite_plugin/config_helper.py
@@ -34,7 +34,7 @@ def get_config() -> dict:
         config['MANIFEST'] = Path(config['MANIFEST'])
     
     if config['HOT_FILE'] is None:
-        config['HOT_FILE'] = str(getattr(settings, 'BASE_DIR') / '.hotfile')
+        config['HOT_FILE'] = str(Path(getattr(settings, 'BASE_DIR')) / '.hotfile')
     elif isinstance(config['HOT_FILE'], Path):
         config['HOT_FILE'] = str(config['HOT_FILE'])
     return config


### PR DESCRIPTION
I needed to convert the BASE_DIR setting to a path before using the '/' operand. 

I am running in Python 3.12. maybe that's the difference?